### PR TITLE
Remove StaticAsset module to allow a simple error handler (avoid throws E_NOENT)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
-        "@nestjs/serve-static": "^4.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "twing": "^6.0.0-alpha.1"
@@ -800,37 +799,6 @@
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
-    },
-    "node_modules/@nestjs/serve-static": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-4.0.0.tgz",
-      "integrity": "sha512-8cTrNV2ngdHIjiLNsXePnw0+KY1ThrZGz/WeyAG5gIvmZNDbnZBOrPoYlKL+MOzlXlQStxR5jKLYmn+nJeoncQ==",
-      "dependencies": {
-        "path-to-regexp": "0.2.5"
-      },
-      "peerDependencies": {
-        "@fastify/static": "^6.5.0",
-        "@nestjs/common": "^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^9.0.0 || ^10.0.0",
-        "express": "^4.18.1",
-        "fastify": "^4.7.0"
-      },
-      "peerDependenciesMeta": {
-        "@fastify/static": {
-          "optional": true
-        },
-        "express": {
-          "optional": true
-        },
-        "fastify": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nestjs/serve-static/node_modules/path-to-regexp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
-      "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7180,21 +7148,6 @@
             "ora": "5.4.1",
             "rxjs": "7.8.1"
           }
-        }
-      }
-    },
-    "@nestjs/serve-static": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-4.0.0.tgz",
-      "integrity": "sha512-8cTrNV2ngdHIjiLNsXePnw0+KY1ThrZGz/WeyAG5gIvmZNDbnZBOrPoYlKL+MOzlXlQStxR5jKLYmn+nJeoncQ==",
-      "requires": {
-        "path-to-regexp": "0.2.5"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
-          "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
-    "@nestjs/serve-static": "^4.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "twing": "^6.0.0-alpha.1"

--- a/src/app.filters.ts
+++ b/src/app.filters.ts
@@ -1,0 +1,23 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(_exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request>();
+    const response = ctx.getResponse<Response>();
+
+    const httpStatus = _exception.getStatus();
+
+    response.render('error.html.twig', {
+      status: httpStatus,
+      path: request.url,
+    });
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,16 +1,18 @@
 import { Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { HttpExceptionFilter } from './app.filters';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { ServeStaticModule } from '@nestjs/serve-static';
-import { join } from 'path';
 
 @Module({
-  imports: [
-    ServeStaticModule.forRoot({
-      rootPath: join(__dirname, '..', 'public'),
-    }),
-  ],
+  imports: [],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_FILTER,
+      useClass: HttpExceptionFilter,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,8 @@ async function bootstrap() {
   const loader = new TwingLoaderFilesystem('templates');
   const twing = new TwingEnvironment(loader, { strict_variables: true });
 
+  app.useStaticAssets(path.join(__dirname, '..', 'public'));
+
   app.engine('twig', (filePath, options, callback) => {
     twing
       .render(path.relative('templates', filePath), options)
@@ -18,6 +20,7 @@ async function bootstrap() {
   });
   app.setBaseViewsDir('templates');
   app.setViewEngine('twig');
+
   await app.listen(3000);
 }
 bootstrap();

--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -1,0 +1,10 @@
+{% extends "base.html.twig" %}
+{% block title %}Error {{ status }}{% endblock %}
+{% block body %}
+    <p>
+        <b>Error {{ status }}</b>
+    </p>
+    <p>
+        <i>{{ path }}</i>
+    </p>
+{% endblock %}


### PR DESCRIPTION
The NestJS StaticAsset module throws a E_NOENT exception in case of file not found.
This prevents HttpException handlers to be filtered and force the use of a catch-all handler.
To solve the issue the NestJS useStaticAsset() method is used instead, allowing simplification of code.